### PR TITLE
Inspirations from https://www.npmjs.com/package/hapi-auth-bearer-token

### DIFF
--- a/request-signature/index.js
+++ b/request-signature/index.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const Boom = require('@hapi/boom');
+const Hoek = require('@hapi/hoek');
+const Joi = require('@hapi/joi');
+
+// Declare Internals
+const internals = {};
+
+internals.schema = Joi.object().keys({
+    validate: Joi.func().required()
+});
+
+internals.implementation = (server, options) => {
+    const scheme = {
+        authenticate: async (request, h) => {
+            console.log({ request });
+            console.log({ h });
+        }
+    };
+
+    return scheme;
+};
+
+exports.plugin = {
+    name: 'request-signature',
+    version: '1.0.0',
+    register: (server, options) =>
+        server.auth.scheme('request-signature', internals.implementation)
+};

--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ import inert from '@hapi/inert';
 import vision from '@hapi/vision';
 import Pack from './package.json';
 import rateLimiter from 'hapi-rate-limit';
-
+import { plugin } from './request-signature';
 import cors from 'hapi-cors';
 import serverConfig from 'config/server';
 import hapiPaginationOptions from 'utils/paginationConstants';
@@ -33,6 +33,13 @@ export let server;
 
 const initServer = async () => {
     server = Hapi.server(serverConfig);
+
+    //register custom plugin
+    await server.register({
+        plugin: plugin
+    });
+
+    server.auth.strategy('signature', 'request-signature', {});
 
     // Register hapi swagger plugin
     await server.register([


### PR DESCRIPTION
Used template for testing the custom plugin at this point of code the plugin is registered. We have to migrate necessary code from our scheme. 