### PR TITLE
Ignore tmp files generated by vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,9 @@ typings/
 
 # DS_Store
 .DS_Store
+
+# Vim swap/tmp files
+*~
+*.swp
+*.swo
+


### PR DESCRIPTION
This PR ignores swap files generated by vim in workdir when the file is being edited, from being accidentally pushed to the repo.