### PR TITLE
feat(logging): implemented rTracer for request ID Tracking

### DIFF
--- a/config/db.js
+++ b/config/db.js
@@ -2,7 +2,6 @@ const mysql2 = require('mysql2');
 module.exports = {
     url: process.env.DB_URI,
     host: process.env.MYSQL_HOST,
-    logging: true,
     dialectModule: mysql2,
     dialect: 'mysql',
     pool: {

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -12,7 +12,11 @@ let sequelize;
 if (process.env.NODE_ENV === 'test') {
     sequelize = new SequelizeMock();
 } else {
-    sequelize = new Sequelize(dbConfig.url, dbConfig);
+    const { getLogger } = require('@utils');
+    sequelize = new Sequelize(dbConfig.url, {
+        logging: getLogger(),
+        ...dbConfig
+    });
 }
 
 export const models = {

--- a/utils/index.js
+++ b/utils/index.js
@@ -178,6 +178,7 @@ export const stringifyWithCheck = message => {
         }
     }
 };
+
 export const logger = () => {
     const rTracerFormat = printf(info => {
         const rid = rTracer.id();
@@ -195,4 +196,15 @@ export const logger = () => {
         format: combine(timestamp(), rTracerFormat),
         transports: [new transports.Console()]
     });
+};
+
+export const getLogger = () => {
+    if (process.env.NODE_ENV === 'development') {
+        // eslint-disable-next-line no-console
+        return console.log;
+    } else if (process.env.NODE_ENV === 'test') {
+        return false;
+    } else {
+        return args => logger().info(args);
+    }
 };

--- a/utils/tests/index.test.js
+++ b/utils/tests/index.test.js
@@ -60,6 +60,32 @@ describe('util tests', () => {
         });
     });
 
+    describe('getLogger', () => {
+        it('should return console.log for env develop', () => {
+            process.env = {
+                NODE_ENV: 'development'
+            };
+            const { getLogger } = require('@utils');
+            expect(getLogger()).toEqual(console.log);
+        });
+
+        it('should return false for env test', () => {
+            process.env = {
+                NODE_ENV: 'test'
+            };
+            const { getLogger } = require('@utils');
+            expect(getLogger()).toEqual(false);
+        });
+
+        it('should return function type for any other env', () => {
+            process.env = {
+                NODE_ENV: 'prod'
+            };
+            const { getLogger } = require('@utils');
+            expect(typeof getLogger()).toEqual('function');
+        });
+    });
+
     describe('isScopeHigher', () => {
         it('should check if the token has higher scope ', async () => {
             const { isScopeHigher } = require('@utils');


### PR DESCRIPTION
### Description

Implemented rTracer to log request received and response sent back to the client.
Request ID is generated for each request and is also placed into the headers as `x-request-id` for each response sent out.

### Steps to Reproduce / Test

Tests can be ran using:
```
yarn test
```

### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)
